### PR TITLE
Support transforming a plain enum

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "typescript.tsdk": "node_modules/typescript/lib",
     "cSpell.language": "en",
     "cSpell.words": [
-        "Annotationify"
+        "Annotationify",
+        "clazz"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ This is a simple tool to migrate full-fledged TypeScript code to type-annotated 
 | ------------------------------------------- | ------ | ------------------------------------------------------------------ |
 | Parameter Properties                        | ✅     |                                                                    |
 | Parameter Properties with `super()` call    | ✅     |                                                                    |
-| Plain Enum                                  | ❌     |                                                                    |
+| Plain Enum                                  | ✅     | See [#3](https://github.com/nicojs/type-annotationify/issues/3)    |
 | Number Enum                                 | ❌     |                                                                    |
 | String Enum                                 | ❌     |                                                                    |
+| Const Enum                                  | ❌     |                                                                    |
 | Type assertion expressions                  | ❌     | I.e. `<string>value` --> `value as string`                         |
 | Namespaces                                  | ❌     | This might turn out to be impossible to do, to be investigated     |
 | Rewrite file extensions in import specifier | ❌     | This might be included with an option in the future With an option |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "type-annotationify",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Convert TS to Type-Annotation-only-TS",
   "license": "Apache-2.0",
   "author": "nicojs",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
     "node": ">=22"
   },
   "scripts": {
-    "all": "npm run format && npm run test",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "all": "npm run format && && npm run build && npm run test",
     "format:fix": "npm run format -- --write",
     "format": "prettier --check src/**/*.ts README.md",
+    "build": "tsc -b",
     "test": "node --test --experimental-strip-types --test-reporter=spec src/**/*.spec.ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "clean": "rm -rf dist *.tsbuildinfo",
-    "all": "npm run format && && npm run build && npm run test",
+    "all": "npm run format && npm run build && npm run test",
     "format:fix": "npm run format -- --write",
     "format": "prettier --check src/**/*.ts README.md",
     "build": "tsc -b",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,9 +16,9 @@ export async function runTypeAnnotationify(args: string[]) {
       (async () => {
         const content = await fs.readFile(file, 'utf-8');
         const sourceFile = parse(file, content);
-        const { source, changed } = transform(sourceFile);
+        const { node, changed } = transform(sourceFile);
         if (changed) {
-          const transformedContent = print(source);
+          const transformedContent = print(node);
           await fs.writeFile(file, transformedContent);
           console.log(`✅ (changed) ${file}`);
         } else {

--- a/src/transform.spec.ts
+++ b/src/transform.spec.ts
@@ -179,6 +179,20 @@ describe('transform', async () => {
           } satisfies Record<MessageKind, MessageKindKeys> & Record<MessageKindKeys, MessageKind>;`,
       );
     });
+    await it('should use unique name for the keys enum', async () => {
+      await scenario(
+        `enum MessageKind { Start }; 
+         let MessageKindKeys = 0;
+         `,
+        `type MessageKind = 0;
+         type MessageKindKeys_1 = 'Start';
+         const MessageKind = {
+          0: 'Start',
+          Start: 0
+          } satisfies Record<MessageKind, MessageKindKeys_1> & Record<MessageKindKeys_1, MessageKind>;
+         let MessageKindKeys = 0;`,
+      );
+    });
 
     await it('should not transform an initialized number enum (yet)', async () => {
       await scenario('enum MessageKind { Start = 1, Work, Stop }');

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,4 +1,6 @@
-import ts, { type Identifier } from 'typescript';
+import ts from 'typescript';
+import { transformConstructorParameters } from './transformers/constructor-parameters.ts';
+import { transformEnum } from './transformers/enums.ts';
 export function parse(fileName: string, content: string) {
   return ts.createSourceFile(
     fileName,
@@ -12,118 +14,38 @@ export function print(source: ts.SourceFile): string {
   return printer.printFile(source);
 }
 
-export interface TransformResult {
+export interface TransformResult<TNode extends ts.Node | ts.Node[]> {
   changed: boolean;
-  source: ts.SourceFile;
+  node: TNode;
 }
 
-export function transform(source: ts.SourceFile): TransformResult {
+export function transform(
+  source: ts.SourceFile,
+): TransformResult<ts.SourceFile> {
   let changed = false;
   return {
-    source: ts.visitEachChild(source, transformNode, undefined),
+    node: ts.visitEachChild(source, transformNode, undefined),
     changed,
   };
 
-  function transformNode(node: ts.Node): ts.Node {
+  function transformNode(node: ts.Node): ts.Node | ts.Node[] {
+    let resultingNode: ts.Node | ts.Node[] = node;
     if (ts.isClassDeclaration(node)) {
-      const constructor = node.members.find((member) =>
-        ts.isConstructorDeclaration(member),
-      );
-      const constructorParameterProperties: ts.ParameterDeclaration[] = [];
-      if (constructor) {
-        const constructorParams = constructor.parameters;
-        constructorParams.forEach((param) => {
-          if (ts.isParameterPropertyDeclaration(param, param.parent)) {
-            constructorParameterProperties.push(param);
-          }
-        });
-      }
-      if (constructorParameterProperties.length > 0) {
-        changed = true;
-        return ts.factory.updateClassDeclaration(
-          node,
-          node.modifiers,
-          node.name,
-          node.typeParameters,
-          node.heritageClauses,
-          [
-            ...toClassProperties(constructorParameterProperties),
-            ...node.members.map((member) => {
-              if (!ts.isConstructorDeclaration(member)) {
-                return member;
-              }
-
-              const statements: readonly ts.Statement[] =
-                member.body?.statements || [];
-
-              const indexOfSuperCall = statements.findIndex(
-                (statement) =>
-                  ts.isExpressionStatement(statement) &&
-                  ts.isCallExpression(statement.expression) &&
-                  statement.expression.expression.kind ===
-                    ts.SyntaxKind.SuperKeyword,
-              );
-
-              return ts.factory.updateConstructorDeclaration(
-                member,
-                member.modifiers,
-                removeModifiersFromProperties(member.parameters),
-                ts.factory.createBlock([
-                  ...statements.slice(0, indexOfSuperCall + 1),
-                  ...toPropertyInitializers(constructorParameterProperties),
-                  ...statements.slice(indexOfSuperCall + 1),
-                ]),
-              );
-            }),
-          ],
-        );
-      }
+      const result = transformConstructorParameters(node);
+      changed ||= result.changed;
+      resultingNode = result.node;
     }
-    return ts.visitEachChild(node, transformNode, undefined);
+    if (ts.isEnumDeclaration(node)) {
+      const result = transformEnum(node);
+      changed ||= result.changed;
+      resultingNode = result.node;
+    }
+    if (Array.isArray(resultingNode)) {
+      return resultingNode.map((node) =>
+        ts.visitEachChild(node, transformNode, undefined),
+      );
+    } else {
+      return ts.visitEachChild(resultingNode, transformNode, undefined);
+    }
   }
-}
-function toPropertyInitializers(
-  constructorParameterProperties: ts.ParameterDeclaration[],
-) {
-  return constructorParameterProperties.map((param) => {
-    return ts.factory.createExpressionStatement(
-      ts.factory.createBinaryExpression(
-        ts.factory.createPropertyAccessExpression(
-          ts.factory.createThis(),
-          (param.name as Identifier).text,
-        ),
-        ts.SyntaxKind.EqualsToken,
-        ts.factory.createIdentifier((param.name as Identifier).text),
-      ),
-    );
-  });
-}
-function toClassProperties(parameterProperties: ts.ParameterDeclaration[]) {
-  return parameterProperties.map((param) => {
-    return ts.factory.createPropertyDeclaration(
-      param.modifiers,
-      (param.name as Identifier).text,
-      param.questionToken,
-      /* type */ undefined,
-      param.initializer,
-    );
-  });
-}
-function removeModifiersFromProperties(
-  params: ts.NodeArray<ts.ParameterDeclaration>,
-): readonly ts.ParameterDeclaration[] {
-  return params.map((param) => {
-    if (ts.isParameterPropertyDeclaration(param, param.parent)) {
-      return ts.factory.updateParameterDeclaration(
-        param,
-        /* modifiers */ undefined,
-        param.dotDotDotToken,
-        param.name,
-        param.questionToken,
-        param.type,
-        param.initializer,
-      );
-    }
-    return param;
-  });
 }

--- a/src/transformers/constructor-parameters.ts
+++ b/src/transformers/constructor-parameters.ts
@@ -1,0 +1,108 @@
+import ts from 'typescript';
+import type { TransformResult } from '../transform.ts';
+
+export function transformConstructorParameters(
+  clazz: ts.ClassDeclaration,
+): TransformResult<ts.ClassDeclaration> {
+  const constructor = clazz.members.find((member) =>
+    ts.isConstructorDeclaration(member),
+  );
+  const constructorParameterProperties: ts.ParameterDeclaration[] = [];
+  if (constructor) {
+    const constructorParams = constructor.parameters;
+    constructorParams.forEach((param) => {
+      if (ts.isParameterPropertyDeclaration(param, param.parent)) {
+        constructorParameterProperties.push(param);
+      }
+    });
+  }
+  if (constructorParameterProperties.length === 0) {
+    return { changed: false, node: clazz };
+  }
+  return {
+    changed: true,
+    node: ts.factory.updateClassDeclaration(
+      clazz,
+      clazz.modifiers,
+      clazz.name,
+      clazz.typeParameters,
+      clazz.heritageClauses,
+      [
+        ...toClassProperties(constructorParameterProperties),
+        ...clazz.members.map((member) => {
+          if (!ts.isConstructorDeclaration(member)) {
+            return member;
+          }
+
+          const statements: readonly ts.Statement[] =
+            member.body?.statements || [];
+
+          const indexOfSuperCall = statements.findIndex(
+            (statement) =>
+              ts.isExpressionStatement(statement) &&
+              ts.isCallExpression(statement.expression) &&
+              statement.expression.expression.kind ===
+                ts.SyntaxKind.SuperKeyword,
+          );
+
+          return ts.factory.updateConstructorDeclaration(
+            member,
+            member.modifiers,
+            removeModifiersFromProperties(member.parameters),
+            ts.factory.createBlock([
+              ...statements.slice(0, indexOfSuperCall + 1),
+              ...toPropertyInitializers(constructorParameterProperties),
+              ...statements.slice(indexOfSuperCall + 1),
+            ]),
+          );
+        }),
+      ],
+    ),
+  };
+}
+
+function toPropertyInitializers(
+  constructorParameterProperties: ts.ParameterDeclaration[],
+) {
+  return constructorParameterProperties.map((param) => {
+    return ts.factory.createExpressionStatement(
+      ts.factory.createBinaryExpression(
+        ts.factory.createPropertyAccessExpression(
+          ts.factory.createThis(),
+          (param.name as ts.Identifier).text,
+        ),
+        ts.SyntaxKind.EqualsToken,
+        ts.factory.createIdentifier((param.name as ts.Identifier).text),
+      ),
+    );
+  });
+}
+function toClassProperties(parameterProperties: ts.ParameterDeclaration[]) {
+  return parameterProperties.map((param) => {
+    return ts.factory.createPropertyDeclaration(
+      param.modifiers,
+      (param.name as ts.Identifier).text,
+      param.questionToken,
+      /* type */ undefined,
+      param.initializer,
+    );
+  });
+}
+function removeModifiersFromProperties(
+  params: ts.NodeArray<ts.ParameterDeclaration>,
+): readonly ts.ParameterDeclaration[] {
+  return params.map((param) => {
+    if (ts.isParameterPropertyDeclaration(param, param.parent)) {
+      return ts.factory.updateParameterDeclaration(
+        param,
+        /* modifiers */ undefined,
+        param.dotDotDotToken,
+        param.name,
+        param.questionToken,
+        param.type,
+        param.initializer,
+      );
+    }
+    return param;
+  });
+}

--- a/src/transformers/enums.ts
+++ b/src/transformers/enums.ts
@@ -10,14 +10,21 @@ export function transformEnum(
   }
 
   // TODO: Implement enums with computed property names
-  if (enumDeclaration.members.some((member) => ts.isComputedPropertyName(member.name))) {
+  if (
+    enumDeclaration.members.some((member) =>
+      ts.isComputedPropertyName(member.name),
+    )
+  ) {
     return { changed: false, node: [enumDeclaration] as const };
   }
 
   const enumMap = new Map(
     enumDeclaration.members.map((member, index) => [member, index] as const),
   );
-  const keysUnion = `${enumDeclaration.name.text}Keys`;
+  const keysUnion = ts.factory.createUniqueName(
+    `${enumDeclaration.name.text}Keys`,
+    ts.GeneratedIdentifierFlags.Optimistic
+  );
   return {
     changed: true,
     node: [
@@ -35,7 +42,7 @@ export function transformEnum(
       ),
       ts.factory.createTypeAliasDeclaration(
         undefined,
-        ts.factory.createIdentifier(keysUnion),
+        keysUnion,
         undefined,
         ts.factory.createUnionTypeNode(
           enumDeclaration.members.map((member) => {

--- a/src/transformers/enums.ts
+++ b/src/transformers/enums.ts
@@ -23,7 +23,7 @@ export function transformEnum(
   );
   const keysUnion = ts.factory.createUniqueName(
     `${enumDeclaration.name.text}Keys`,
-    ts.GeneratedIdentifierFlags.Optimistic
+    ts.GeneratedIdentifierFlags.Optimistic,
   );
   return {
     changed: true,

--- a/src/transformers/enums.ts
+++ b/src/transformers/enums.ts
@@ -1,0 +1,107 @@
+import ts from 'typescript';
+import type { TransformResult } from '../transform.ts';
+
+export function transformEnum(
+  enumDeclaration: ts.EnumDeclaration,
+): TransformResult<ts.Node[]> {
+  // TODO: Implement enums with initializers
+  if (enumDeclaration.members.some((member) => member.initializer)) {
+    return { changed: false, node: [enumDeclaration] as const };
+  }
+
+  // TODO: Implement enums with computed property names
+  if (enumDeclaration.members.some((member) => ts.isComputedPropertyName(member.name))) {
+    return { changed: false, node: [enumDeclaration] as const };
+  }
+
+  const enumMap = new Map(
+    enumDeclaration.members.map((member, index) => [member, index] as const),
+  );
+  const keysUnion = `${enumDeclaration.name.text}Keys`;
+  return {
+    changed: true,
+    node: [
+      ts.factory.createTypeAliasDeclaration(
+        enumDeclaration.modifiers,
+        enumDeclaration.name,
+        undefined,
+        ts.factory.createUnionTypeNode(
+          enumDeclaration.members.map((member) =>
+            ts.factory.createLiteralTypeNode(
+              ts.factory.createNumericLiteral(enumMap.get(member)!),
+            ),
+          ),
+        ),
+      ),
+      ts.factory.createTypeAliasDeclaration(
+        undefined,
+        ts.factory.createIdentifier(keysUnion),
+        undefined,
+        ts.factory.createUnionTypeNode(
+          enumDeclaration.members.map((member) => {
+            if (ts.isComputedPropertyName(member.name)) {
+              throw new Error('Computed property names are not supported yet');
+            }
+            return ts.factory.createLiteralTypeNode(
+              ts.factory.createStringLiteral(member.name.text),
+            );
+          }),
+        ),
+      ),
+      ts.factory.createVariableStatement(
+        enumDeclaration.modifiers,
+        ts.factory.createVariableDeclarationList(
+          [
+            ts.factory.createVariableDeclaration(
+              enumDeclaration.name,
+              undefined,
+              undefined,
+              ts.factory.createSatisfiesExpression(
+                ts.factory.createObjectLiteralExpression(
+                  [
+                    ...enumDeclaration.members.map((member) => {
+                      if (ts.isComputedPropertyName(member.name)) {
+                        throw new Error(
+                          'Computed property names are not supported yet',
+                        );
+                      }
+                      return ts.factory.createPropertyAssignment(
+                        ts.factory.createNumericLiteral(enumMap.get(member)!),
+                        ts.factory.createStringLiteral(member.name.text),
+                      );
+                    }),
+                    ...enumDeclaration.members.map((member) => {
+                      if (ts.isComputedPropertyName(member.name)) {
+                        throw new Error(
+                          'Computed property names are not supported yet',
+                        );
+                      }
+                      return ts.factory.createPropertyAssignment(
+                        ts.factory.createStringLiteral(member.name.text),
+                        ts.factory.createNumericLiteral(enumMap.get(member)!),
+                      );
+                    }),
+                  ],
+                  true,
+                ),
+                // satisfies...
+                ts.factory.createIntersectionTypeNode([
+                  ts.factory.createTypeReferenceNode('Record', [
+                    ts.factory.createTypeReferenceNode(enumDeclaration.name),
+                    ts.factory.createTypeReferenceNode(keysUnion),
+                  ]),
+
+                  ts.factory.createTypeReferenceNode('Record', [
+                    ts.factory.createTypeReferenceNode(keysUnion),
+                    ts.factory.createTypeReferenceNode(enumDeclaration.name),
+                  ]),
+                ]),
+              ),
+            ),
+          ],
+          ts.NodeFlags.Const,
+        ),
+      ),
+    ],
+  };
+}


### PR DESCRIPTION
Support a plain enum.

This:

```ts
enum MessageKind { Start, Work, Stop }
```

Gets type-annotationified as:

```ts
type MessageKind = 0 | 1 | 2;
type MessageKindKeys = 'Start' | 'Work' | 'Stop';
const MessageKind = {
  Start: 0,
  Work: 1,
  Stop: 2,
  0: 'Start',
  1: 'Work',
  2: 'Stop'
} satisfies Record<MessageKind, MessageKindKeys> & Record<MessageKindKeys, MessageKind>;
```